### PR TITLE
Make service optional in use

### DIFF
--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -265,7 +265,7 @@ export interface FeathersApplication<Services = any, Settings = any> {
    */
   use<L extends keyof Services & string>(
     path: L,
-    service: keyof any extends keyof Services ? ServiceInterface | Application : Services[L],
+    service?: keyof any extends keyof Services ? ServiceInterface | Application : Services[L],
     options?: ServiceOptions<keyof any extends keyof Services ? string : keyof Services[L]>
   ): this
 


### PR DESCRIPTION
I'm not sure why this isn't being caught automatically... but we should definitely not skipLibCheck on things we control. If we depend on something with bad TS... perhaps we shouldn't. 

skipLibCheck should remain the default for userland of course.

![Screenshot 2023-06-03 11 35 28](https://github.com/FossPrime/feathers/assets/876076/e804cbf6-bd7f-4528-b252-78252152ac6c)

https://github.com/feathersjs/feathers-chat/blob/dove/feathers-chat-ts/src/app.ts#LL22C40-L22C40
